### PR TITLE
Missing offset entries for the two joker suits results in jokers rend…

### DIFF
--- a/cards.js
+++ b/cards.js
@@ -109,7 +109,7 @@ var cards = (function() {
 		},
 		
 		showCard : function() {
-			var offsets = { "c": 0, "d": 1, "h": 2, "s": 3 };
+			var offsets = { "c": 0, "d": 1, "h": 2, "s": 3, "rj": 2, "bj": 3 };
 			var xpos, ypos;
 			var rank = this.rank;
 			if (rank == 14) {


### PR DESCRIPTION
…ering as facedown red card image. Since the Jokers are the first card position in the heart and spade rows in the cards.png file, mapping these two "suits" to hearts and spades allows the image mapping to pick up the right joker cards when opt.blackJoker or opt.redJoker are set to true.